### PR TITLE
Bump jtd to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "jtd-validate"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,9 +83,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "jtd"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23432373330590802662d62b0088ab52451b6dbf309f1c048c0297c80f77138"
+checksum = "54f0964332e071f2832a3ecd241ec19dcc5ae55992bc573c04b40e69ab95bc52"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jtd-validate"
 description = "Generates example data from JSON Typedef schemas"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT"
 authors = ["JSON Typedef Contributors"]
 edition = "2018"


### PR DESCRIPTION
This PR bumps the dependency on jtd to 0.2.1, fixing a bug due to https://github.com/jsontypedef/json-typedef-rust/pull/13.