### PR TITLE
publish.yml: remove cargo publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,16 +3,6 @@ on:
     types: [published]
 
 jobs:
-  publish_crate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - run: cargo publish
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   release_binary:
     runs-on: ${{ matrix.runs_on }}
     strategy:


### PR DESCRIPTION
This repo does not contain any rust packages meant to be published.